### PR TITLE
NP-1440: Define submodule assign-doi-datacite

### DIFF
--- a/assign-doi-datacite/build.gradle
+++ b/assign-doi-datacite/build.gradle
@@ -1,0 +1,10 @@
+def zalandoVersion = '0.23.0'
+
+dependencies {
+    implementation group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: 'v0.3.3'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
+    implementation group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.2.0'
+    implementation group: 'com.amazonaws.secretsmanager', name: 'aws-secretsmanager-caching-java', version: '1.0.1'
+    implementation group: 'org.zalando', name: 'problem', version: zalandoVersion
+    implementation group: 'org.zalando', name: 'jackson-datatype-problem', version: zalandoVersion
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'nva-datacite-mds'
 include 'assign-doi-proxy-function'
+include 'assign-doi-datacite'


### PR DESCRIPTION
We can get this in right away , just so I have the module defined in latest `develop`. 

Created own module as unsure what is reusable etc from the `assign-doi-proxy-function`, so I named this more according to the drawing, which for me is `assign-doi-datacite` (assign doi, but implementation towards datacite). 